### PR TITLE
Update API return format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@ A RESTful API for interacting with CSH Quotefault, no webgui required!
 
 ```json
 {
-  "533": {
-    "quote": "I can't wait to get to New York and kill everyone", 
-    "quoteTime": "Fri, 27 Oct 2017 22:14:31 GMT", 
-    "speaker": "Tanat", 
-    "submitter": "matted"
-  }
+    "id": "533",
+    "quote": "I can't wait to get to New York and kill everyone",
+    "submitter": "matted",
+    "speaker": "Tanat",
+    "quoteTime": "Fri, 27 Oct 2017 22:14:31 GMT"
 }
 ```
 
@@ -48,12 +47,11 @@ Returns the newest result from the submitter = `matted`
 
 ```json
 {
-  "533": {
-    "quote": "I can't wait to get to New York and kill everyone", 
-    "quoteTime": "Fri, 27 Oct 2017 22:14:31 GMT", 
-    "speaker": "Tanat", 
-    "submitter": "matted"
-  }
+    "id": "533",
+    "quote": "I can't wait to get to New York and kill everyone",
+    "submitter": "matted",
+    "speaker": "Tanat",
+    "quoteTime": "Fri, 27 Oct 2017 22:14:31 GMT"
 }
 ```
 


### PR DESCRIPTION
Fixes #42 

Updates the README to the new API format:

```json
    "id": quote.id,
    "quote": quote.quote,
    "submitter": quote.submitter,
    "speaker": quote.speaker,
    "quoteTime": quote.quote_time
```

Note this isn't exactly the same as the issue, as the issue includes a trailing comma on the object, which isn't valid JSON. I assume the actual return value doesn't have it, but feel free to correct me.